### PR TITLE
Wasm caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,7 @@ dependencies = [
  "cw20 1.1.2",
  "derivative",
  "env_logger",
+ "file-lock",
  "hex",
  "hex-literal",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +446,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
+ "cargo_metadata",
  "cosmrs",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3011,6 +3044,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,9 @@ wasmer = { version = "=4.2.2", default-features = false, features = [
     "singlepass",
 ] }
 
-# For finding Cargo target dir
-cargo_metadata = "0.18"
+# Caching
+cargo_metadata = "0.18" # For finding Cargo target dir
+file-lock = "2.1"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ wasmer = { version = "=4.2.2", default-features = false, features = [
     "singlepass",
 ] }
 
+# For finding Cargo target dir
+cargo_metadata = "0.18"
+
 [dev-dependencies]
 hex = "0.4.3"
 hex-literal = "0.4.1"

--- a/examples/cavern_test_app.rs
+++ b/examples/cavern_test_app.rs
@@ -58,7 +58,7 @@ pub fn test() -> anyhow::Result<()> {
 
     let runtime = Runtime::new()?;
     let chain = PHOENIX_1;
-    let remote_channel = RemoteChannel::new(&runtime, chain.clone())?;
+    let remote_channel = RemoteChannel::new(&runtime, chain.clone(), "")?;
 
     let wasm = WasmKeeper::<Empty, Empty>::new()
         .with_remote(remote_channel.clone())

--- a/examples/cavern_test_app.rs
+++ b/examples/cavern_test_app.rs
@@ -58,11 +58,7 @@ pub fn test() -> anyhow::Result<()> {
 
     let runtime = Runtime::new()?;
     let chain = PHOENIX_1;
-    let remote_channel = RemoteChannel::new(
-        &runtime,
-        chain.clone(),
-        chain.network_info.pub_address_prefix,
-    )?;
+    let remote_channel = RemoteChannel::new(&runtime, chain.clone())?;
 
     let wasm = WasmKeeper::<Empty, Empty>::new()
         .with_remote(remote_channel.clone())

--- a/examples/cousin_test.rs
+++ b/examples/cousin_test.rs
@@ -70,11 +70,7 @@ fn test() -> AnyResult<()> {
 
     let runtime = Runtime::new()?;
     let chain = PHOENIX_1;
-    let remote_channel = RemoteChannel::new(
-        &runtime,
-        chain.clone(),
-        chain.network_info.pub_address_prefix,
-    )?;
+    let remote_channel = RemoteChannel::new(&runtime, chain.clone())?;
 
     let wasm = WasmKeeper::<Empty, Empty>::new()
         .with_remote(remote_channel.clone())

--- a/examples/cousin_test.rs
+++ b/examples/cousin_test.rs
@@ -70,7 +70,7 @@ fn test() -> AnyResult<()> {
 
     let runtime = Runtime::new()?;
     let chain = PHOENIX_1;
-    let remote_channel = RemoteChannel::new(&runtime, chain.clone())?;
+    let remote_channel = RemoteChannel::new(&runtime, chain.clone(), "")?;
 
     let wasm = WasmKeeper::<Empty, Empty>::new()
         .with_remote(remote_channel.clone())

--- a/examples/test_app.rs
+++ b/examples/test_app.rs
@@ -20,11 +20,7 @@ pub fn test() -> anyhow::Result<()> {
 
     let runtime = Runtime::new()?;
     let chain = PHOENIX_1;
-    let remote_channel = RemoteChannel::new(
-        &runtime,
-        chain.clone(),
-        chain.network_info.pub_address_prefix,
-    )?;
+    let remote_channel = RemoteChannel::new(&runtime, chain.clone())?;
     let wasm = WasmKeeper::<Empty, Empty>::new().with_remote(remote_channel.clone());
 
     let bank = BankKeeper::new().with_remote(remote_channel.clone());

--- a/examples/test_app.rs
+++ b/examples/test_app.rs
@@ -20,7 +20,7 @@ pub fn test() -> anyhow::Result<()> {
 
     let runtime = Runtime::new()?;
     let chain = PHOENIX_1;
-    let remote_channel = RemoteChannel::new(&runtime, chain.clone())?;
+    let remote_channel = RemoteChannel::new(&runtime, chain.clone(), "")?;
     let wasm = WasmKeeper::<Empty, Empty>::new().with_remote(remote_channel.clone());
 
     let bank = BankKeeper::new().with_remote(remote_channel.clone());

--- a/src/wasm_emulation/channel.rs
+++ b/src/wasm_emulation/channel.rs
@@ -4,11 +4,7 @@ use tokio::runtime::{Handle, Runtime};
 use tonic::transport::Channel;
 
 /// Simple helper to get the GRPC transport channel
-fn get_channel(
-    chain: impl Into<ChainInfoOwned>,
-    rt: &Runtime,
-) -> anyhow::Result<tonic::transport::Channel> {
-    let chain = chain.into();
+fn get_channel(chain: &ChainInfoOwned, rt: &Runtime) -> anyhow::Result<tonic::transport::Channel> {
     let channel = rt.block_on(GrpcChannel::connect(&chain.grpc_urls, &chain.chain_id))?;
     Ok(channel)
 }
@@ -18,18 +14,18 @@ pub struct RemoteChannel {
     pub rt: Handle,
     pub channel: Channel,
     pub pub_address_prefix: String,
+    // For caching
+    pub chain_id: String,
 }
 
 impl RemoteChannel {
-    pub fn new(
-        rt: &Runtime,
-        chain: impl Into<ChainInfoOwned>,
-        pub_address_prefix: impl Into<String>,
-    ) -> AnyResult<Self> {
+    pub fn new(rt: &Runtime, chain: impl Into<ChainInfoOwned>) -> AnyResult<Self> {
+        let chain: ChainInfoOwned = chain.into();
         Ok(Self {
             rt: rt.handle().clone(),
-            channel: get_channel(chain, rt)?,
-            pub_address_prefix: pub_address_prefix.into(),
+            channel: get_channel(&chain, rt)?,
+            pub_address_prefix: chain.network_info.pub_address_prefix,
+            chain_id: chain.chain_id,
         })
     }
 }

--- a/src/wasm_emulation/channel.rs
+++ b/src/wasm_emulation/channel.rs
@@ -19,7 +19,11 @@ pub struct RemoteChannel {
 }
 
 impl RemoteChannel {
-    pub fn new(rt: &Runtime, chain: impl Into<ChainInfoOwned>) -> AnyResult<Self> {
+    pub fn new(
+        rt: &Runtime,
+        chain: impl Into<ChainInfoOwned>,
+        _: impl Into<String>,
+    ) -> AnyResult<Self> {
         let chain: ChainInfoOwned = chain.into();
         Ok(Self {
             rt: rt.handle().clone(),

--- a/src/wasm_emulation/contract.rs
+++ b/src/wasm_emulation/contract.rs
@@ -579,7 +579,6 @@ mod wasm_caching {
                         file.seek(std::io::SeekFrom::Start(1))?;
                         file.read_to_end(&mut buf)
                             .context("unable to open wasm cache file")?;
-                        dbg!(&buf[0]);
                         buf
                     }
                     // Ready for read

--- a/src/wasm_emulation/contract.rs
+++ b/src/wasm_emulation/contract.rs
@@ -444,7 +444,12 @@ pub fn execute_function<
 mod wasm_caching {
     use super::*;
 
-    use std::{env, fs, io::Read, os::unix::fs::FileExt, path::PathBuf};
+    use std::{
+        env, fs,
+        io::{Read, Seek},
+        os::unix::fs::FileExt,
+        path::PathBuf,
+    };
 
     use anyhow::{bail, Context};
 
@@ -571,6 +576,7 @@ mod wasm_caching {
                 match status {
                     WasmCachingStatus::Ready => {
                         let mut buf = vec![];
+                        file.seek(std::io::SeekFrom::Start(1))?;
                         file.read_to_end(&mut buf)
                             .context("unable to open wasm cache file")?;
                         dbg!(&buf[0]);


### PR DESCRIPTION
Finished wasm cached implementation. This use separate file for each wasm to allow parallelize downloads.
Closes ORC-162

TODO : 
- Automatic u8 representation of enum using the `repr` macro
- Removing the pub_address_prefix argument in the `RemoteChannel` struct