### PR TITLE
Fix no ics20 ack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-multi-test"
-version = "2.0.1"
+version = "2.0.2"
 authors = [
     "Ethan Frey <ethanfrey@users.noreply.github.com>",
     "Dariusz Depta <DariuszDepta@users.noreply.github.com>",

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -333,8 +333,11 @@ impl Module for BankKeeper {
             )?;
         }
 
-        // No acknowledgment needed
-        Ok(AppIbcReceiveResponse::default())
+        Ok(AppIbcReceiveResponse {
+            events: vec![],
+            // Default acknowledgment (defined here https://github.com/cosmos/ibc/blob/main/spec/app/ics-020-fungible-token-transfer/README.md#data-structures)
+            acknowledgement: Some(Binary::new("{\"result\": \"AQ==\"}".as_bytes().to_vec())),
+        })
     }
 
     fn ibc_packet_acknowledge<ExecC, QueryC>(


### PR DESCRIPTION
See: https://github.com/AbstractSDK/cw-orchestrator/actions/runs/10388910804/job/28765657072

Not sure why ack for ics20 receive got removed in abstract-cw-multi-test 2.0. I assume it was an accident, so recovering it